### PR TITLE
Add 2-block confirmation requirement to all transaction receipts

### DIFF
--- a/packages/web/src/components/DepositWithdraw/Action/useApprove.ts
+++ b/packages/web/src/components/DepositWithdraw/Action/useApprove.ts
@@ -46,7 +46,7 @@ export function useApprove() {
 
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
 
   return {
     allowanceQuery, needsApproval, simulation, write, confirmation, resolveToast

--- a/packages/web/src/components/DepositWithdraw/Action/useDeposit.ts
+++ b/packages/web/src/components/DepositWithdraw/Action/useDeposit.ts
@@ -25,7 +25,7 @@ export function useDeposit() {
 
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
 
   return {
     simulation, write, confirmation, resolveToast

--- a/packages/web/src/components/DepositWithdraw/Action/useWithdraw.ts
+++ b/packages/web/src/components/DepositWithdraw/Action/useWithdraw.ts
@@ -26,7 +26,7 @@ export function useWithdraw() {
 
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
 
   return {
     simulation, write, confirmation, resolveToast

--- a/packages/web/src/components/SetAddress.tsx
+++ b/packages/web/src/components/SetAddress.tsx
@@ -30,7 +30,7 @@ function useWrite(
   }), [contract, next, enabled])
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
   return { simulation, write, confirmation, resolveToast }
 }
 

--- a/packages/web/src/components/TransferAddress.tsx
+++ b/packages/web/src/components/TransferAddress.tsx
@@ -21,7 +21,7 @@ function useWrite(
   }), [chainId, address, abi, functionName, args, enabled])
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
   return { simulation, write, confirmation, resolveToast }
 }
 

--- a/packages/web/src/routes/dash/Aside/Vault/Allocator/useAddStrategy.ts
+++ b/packages/web/src/routes/dash/Aside/Vault/Allocator/useAddStrategy.ts
@@ -20,6 +20,6 @@ export function useAddStrategy(strategy: EvmAddress) {
 
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
   return { simulation, write, confirmation, resolveToast }
 }

--- a/packages/web/src/routes/dash/Aside/Vault/Fees/Distribute.tsx
+++ b/packages/web/src/routes/dash/Aside/Vault/Fees/Distribute.tsx
@@ -22,7 +22,7 @@ function useDistribute({ disabled }: { disabled: boolean }) {
   }), [vault, disabled])
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
   return { simulation, write, confirmation, resolveToast }
 }
 

--- a/packages/web/src/routes/dash/Aside/Vault/Fees/SetMaxLoss.tsx
+++ b/packages/web/src/routes/dash/Aside/Vault/Fees/SetMaxLoss.tsx
@@ -38,7 +38,7 @@ function useSetMaxLoss({ maxLoss, disabled }: { maxLoss: bigint, disabled: boole
   }), [vault, disabled, maxLoss])
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
   return { simulation, write, confirmation, resolveToast }
 }
 

--- a/packages/web/src/routes/dash/Aside/Vault/Fees/useClaimable.ts
+++ b/packages/web/src/routes/dash/Aside/Vault/Fees/useClaimable.ts
@@ -39,6 +39,6 @@ export function useClaim() {
   }), [vault, enabled])
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
   return { simulation, write, confirmation, resolveToast }
 }

--- a/packages/web/src/routes/dash/Vault/tabs/Accountant/SetAddress/index.tsx
+++ b/packages/web/src/routes/dash/Vault/tabs/Accountant/SetAddress/index.tsx
@@ -35,7 +35,7 @@ function useWrite(
   }), [contract, next, enabled])
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
   return { simulation, write, confirmation, resolveToast }
 }
 

--- a/packages/web/src/routes/dash/Vault/tabs/Allocator/Allocation.tsx
+++ b/packages/web/src/routes/dash/Vault/tabs/Allocator/Allocation.tsx
@@ -49,7 +49,7 @@ function useSetStrategyDebtRatio(strategy: EvmAddress, ratio: bigint, enabled: b
 
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
   return { simulation, write, confirmation, resolveToast }
 }
 

--- a/packages/web/src/routes/dash/Vault/tabs/Allocator/AutoAllocate.tsx
+++ b/packages/web/src/routes/dash/Vault/tabs/Allocator/AutoAllocate.tsx
@@ -28,7 +28,7 @@ function useSetAutoAllocate(vault: Vault, autoAllocate: boolean, enabled: boolea
   }), [vault, autoAllocate, enabled])
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
   return { simulation, write, confirmation, resolveToast }
 }
 

--- a/packages/web/src/routes/dash/Vault/tabs/Allocator/Revoke.tsx
+++ b/packages/web/src/routes/dash/Vault/tabs/Allocator/Revoke.tsx
@@ -25,7 +25,7 @@ function useRevoke(vault: EvmAddress, strategy: EvmAddress, enabled: boolean) {
 
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
 
   return { simulation, write, confirmation, resolveToast }
 }

--- a/packages/web/src/routes/dash/Vault/tabs/Allocator/useSetMaxDebt.ts
+++ b/packages/web/src/routes/dash/Vault/tabs/Allocator/useSetMaxDebt.ts
@@ -19,6 +19,6 @@ export function useSetMaxDebt(strategy: EvmAddress, maxDebt: bigint | undefined)
 
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
   return { simulation, write, confirmation, resolveToast }
 }

--- a/packages/web/src/routes/dash/Vault/tabs/Allocator/useSetMinimumChange.ts
+++ b/packages/web/src/routes/dash/Vault/tabs/Allocator/useSetMinimumChange.ts
@@ -20,6 +20,6 @@ export function useSetMinimumChange(minimumChange: bigint | undefined) {
 
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
   return { simulation, write, confirmation, resolveToast }
 }

--- a/packages/web/src/routes/dash/Vault/tabs/Fees/SetCustomConfig.tsx
+++ b/packages/web/src/routes/dash/Vault/tabs/Fees/SetCustomConfig.tsx
@@ -37,7 +37,7 @@ export function useSetCustomConfig(options: FeeConfigOptions) {
   }), [vault, options])
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
   return { simulation, write, confirmation, resolveToast }
 }
 

--- a/packages/web/src/routes/dash/Vault/tabs/Roles/SetRoles/index.tsx
+++ b/packages/web/src/routes/dash/Vault/tabs/Roles/SetRoles/index.tsx
@@ -61,7 +61,7 @@ function useWrite({
 
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
   return { simulation, write, confirmation, resolveToast }
 }
 

--- a/packages/web/src/routes/dash/Vault/tabs/Strategies/StrategyDetail.tsx
+++ b/packages/web/src/routes/dash/Vault/tabs/Strategies/StrategyDetail.tsx
@@ -47,7 +47,7 @@ function useSetStrategyDebtRatio(strategy: EvmAddress, ratio: bigint, enabled: b
 
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
   return { simulation, write, confirmation, resolveToast }
 }
 

--- a/packages/web/src/routes/dash/Vault/tabs/Strategies/UseDefaultQueue.tsx
+++ b/packages/web/src/routes/dash/Vault/tabs/Strategies/UseDefaultQueue.tsx
@@ -28,7 +28,7 @@ function useSetUseDefaultQueue(vault: Vault, useDefaultQueue: boolean, enabled: 
   }), [vault, useDefaultQueue, enabled])
   const simulation = useSimulateContract(parameters)
   const { write, resolveToast } = useWriteContract()
-  const confirmation = useWaitForTransactionReceipt({ hash: write.data })
+  const confirmation = useWaitForTransactionReceipt({ hash: write.data, confirmations: 2 })
   return { simulation, write, confirmation, resolveToast }
 }
 


### PR DESCRIPTION
This change adds a confirmations: 2 parameter to all useWaitForTransactionReceipt hooks throughout the application to improve transaction finality guarantees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)