### PR TITLE
Make reports table use full container width

### DIFF
--- a/packages/web/src/routes/dash/Vault/tabs/Reports.tsx
+++ b/packages/web/src/routes/dash/Vault/tabs/Reports.tsx
@@ -179,7 +179,7 @@ function Suspender() {
       next={fetchFrame}
       hasMore={hasMoreFrames}
       loader={<></>}>
-      <table className="border-separate border-spacing-4">
+      <table className="w-full border-separate border-spacing-4">
         <thead>
           <tr className="text-neutral-400">
             <th className="w-52 text-left">TX</th>


### PR DESCRIPTION
### Summary
Fix reports table layout on large screens - the table was scrunched to the left instead of spanning the full container width. Added `w-full` class to match the skeleton table behavior.

### How to review
- Check `packages/web/src/routes/dash/Vault/tabs/Reports.tsx` - single line change adding `w-full` to the table element
- View any vault's Reports tab on a wide screen to verify the table spans full width

### Test plan
- [x] Manual: Open a vault with reports, view on a large screen, confirm table uses full container width

### Risk / impact
None