### PR TITLE
Reverse sparkline data order in Finder items

### DIFF
--- a/packages/web/src/components/Finder/useFinderItems.ts
+++ b/packages/web/src/components/Finder/useFinderItems.ts
@@ -135,6 +135,11 @@ query Query {
 `
 
 function vaultToFinderItem(vault: any, label: 'yVault' | 'yStrategy' | 'v3' | 'erc4626' | 'accountant', metadata?: any): FinderItem {
+  const sparklines = {
+    tvl: vault.sparklines?.tvl?.map((s: any) => s.close).reverse() ?? [],
+    apy: vault.sparklines?.apy?.map((s: any) => s.close).reverse() ?? []
+  }
+
   return {
     label,
     chainId: parseInt(vault.chainId),
@@ -158,10 +163,7 @@ function vaultToFinderItem(vault: any, label: 'yVault' | 'yStrategy' | 'v3' | 'e
     },
     tvl: vault.tvl?.close,
     apy: vault.apy?.net,
-    sparklines: {
-      tvl: vault.sparklines?.tvl?.map((s: any) => s.close) ?? [],
-      apy: vault.sparklines?.apy?.map((s: any) => s.close) ?? []
-    },
+    sparklines,
     addressIndex: [vault.address, ...(vault.strategies ?? []), vault.asset.address].join(' ').toLowerCase(),
     metadata
   }


### PR DESCRIPTION
### Summary
The GraphQL query returns sparkline points newest-first, so the TVL and APY sparkline arrays in `vaultToFinderItem` are now reversed to chronological order. This ensures Finder sparklines render left-to-right correctly. Also extracts the `sparklines` object into a local const for readability.

### How to review
- Single file: `packages/web/src/components/Finder/useFinderItems.ts`
- Confirm the API genuinely returns sparkline points newest-first (the `.reverse()` assumes this).

### Test plan
- [ ] Manual: open the Finder and verify TVL/APY sparklines render in chronological order (oldest → newest).

### Risk / impact
Low. UI-only change, no funds/auth/migrations involved. Easy rollback by reverting the single commit.
