### PR TITLE
Update PostCSS to secure release

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,7 @@
         "eslint-config-next": "14.2.6",
         "leven": "4.1.0",
         "mocha": "10.8.2",
-        "postcss": "8.5.6",
+        "postcss": "8.5.18",
         "tailwindcss": "3.4.19",
         "typescript": "5.9.3",
       },
@@ -130,7 +130,7 @@
         "eslint-plugin-react-refresh": "0.4.24",
         "globals": "15.15.0",
         "mocha": "10.8.2",
-        "postcss": "8.5.6",
+        "postcss": "8.5.18",
         "react-indiana-drag-scroll": "2.2.1",
         "tailwind-merge": "2.6.0",
         "tailwindcss": "3.4.19",
@@ -141,6 +141,9 @@
         "vite-plugin-pwa": "0.21.2",
       },
     },
+  },
+  "overrides": {
+    "postcss": "8.5.18",
   },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
@@ -2233,7 +2236,7 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+    "postcss": ["postcss@8.5.18", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ=="],
 
     "postcss-import": ["postcss-import@15.1.0", "", { "dependencies": { "postcss-value-parser": "^4.0.0", "read-cache": "^1.0.0", "resolve": "^1.1.7" }, "peerDependencies": { "postcss": "^8.0.0" } }, "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew=="],
 
@@ -3051,8 +3054,6 @@
 
     "mocha/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 
-    "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
-
     "number-to-bn/bn.js": ["bn.js@4.11.6", "", {}, "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA=="],
 
     "obj-multiplex/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
@@ -3065,7 +3066,7 @@
 
     "porto/zod": ["zod@4.1.13", "", {}, "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig=="],
 
-    "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
@@ -3252,8 +3253,6 @@
     "hash-base/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "mocha/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
-    "next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "obj-multiplex/readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "dev:api": "(cd packages/api && PORT=3001 next dev)",
     "build:api": "(cd packages/api && next build)"
   },
+  "overrides": {
+    "postcss": "8.5.18"
+  },
   "workspaces": ["packages/*"]
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -32,7 +32,7 @@
     "eslint-config-next": "14.2.6",
     "leven": "4.1.0",
     "mocha": "10.8.2",
-    "postcss": "8.5.6",
+    "postcss": "8.5.18",
     "tailwindcss": "3.4.19",
     "typescript": "5.9.3"
   }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-react-refresh": "0.4.24",
     "globals": "15.15.0",
     "mocha": "10.8.2",
-    "postcss": "8.5.6",
+    "postcss": "8.5.18",
     "react-indiana-drag-scroll": "2.2.1",
     "tailwind-merge": "2.6.0",
     "tailwindcss": "3.4.19",


### PR DESCRIPTION
### Summary
Upgrade PostCSS from 8.5.6 to 8.5.18 in the API and web workspaces to resolve CVE-2026-45623 and the related source-map traversal advisory. Add a root override so transitive copies used by Next, Tailwind, and Vite also resolve to the patched version.

### How to review
Review the workspace dependency pins and root override first, then confirm the lockfile resolves a single PostCSS 8.5.18 installation.

### Test plan
- [x] Automated: bun run build
- [x] Automated: bun run build:api
- [x] Dependency verification: bun pm why postcss reports only 8.5.18
- [x] Security verification: bun audit no longer reports PostCSS
- [ ] Automated: web lint (blocked by 175 pre-existing errors in unrelated source files)

### Risk / impact
Low. This is a patch-level build-tool dependency update. The root override also replaces Next.js pinned PostCSS 8.4.31, and both production builds pass. Rollback is the dependency commit.